### PR TITLE
Match for the cmdlinetype in the autocmd pattern

### DIFF
--- a/lua/numb/init.lua
+++ b/lua/numb/init.lua
@@ -50,17 +50,15 @@ local function unpeek(winnr)
 end
 
 function numb.on_cmdline_changed()
-   if vim.fn.getcmdtype() == ':' then
-      local cmd_line = vim.fn.getcmdline()
-      local winnr = api.nvim_get_current_win()
-      if cmd_line == '' or not cmd_line or not cmd_line:find('^%d+$') then
-         -- Cmd line is empty
-         unpeek(winnr)
-      else
-         -- Cmd line contains only one or more numbers
-         peek(winnr, tonumber(cmd_line))
-      end
-   end
+  local cmd_line = vim.fn.getcmdline()
+  local winnr = api.nvim_get_current_win()
+  if cmd_line == '' or not cmd_line or not cmd_line:find('^%d+$') then
+     -- Cmd line is empty
+     unpeek(winnr)
+  else
+     -- Cmd line contains only one or more numbers
+     peek(winnr, tonumber(cmd_line))
+  end
 end
 
 function numb.on_cmdline_exit() unpeek(api.nvim_get_current_win()) end
@@ -70,8 +68,8 @@ function numb.setup(user_opts)
    vim.api.nvim_exec([[
     augroup numb
         autocmd!
-        autocmd CmdlineChanged * lua require('numb').on_cmdline_changed()
-        autocmd CmdlineLeave * lua require('numb').on_cmdline_exit()
+        autocmd CmdlineChanged : lua require('numb').on_cmdline_changed()
+        autocmd CmdlineLeave : lua require('numb').on_cmdline_exit()
     augroup END
    ]], true)
 end


### PR DESCRIPTION
This removes the need to check for the cmdlinetype in the handler
function.