### PR TITLE
Fix unnecessary redraw call on cmdline exit

### DIFF
--- a/lua/numb/init.lua
+++ b/lua/numb/init.lua
@@ -29,7 +29,6 @@ local function peek(winnr, linenr)
    local original_column = win_states[winnr].cursor[2]
    local peek_cursor = {linenr, original_column}
    api.nvim_win_set_cursor(winnr, peek_cursor)
-   vim.cmd('redraw')
 end
 
 local function unpeek(winnr)
@@ -45,14 +44,19 @@ local function unpeek(winnr)
       api.nvim_win_set_cursor(winnr, orig_state.cursor)
    end
    win_states[winnr] = nil
-   vim.cmd('redraw')
 end
 
 function numb.on_cmdline_changed()
    local cmd_line = vim.fn.getcmdline()
    local winnr = api.nvim_get_current_win()
    local num_str = cmd_line:match('^%d+')
-   if num_str then peek(winnr, tonumber(num_str)) else unpeek(winnr) end
+   if num_str then
+      peek(winnr, tonumber(num_str))
+      vim.cmd('redraw')
+   else
+      unpeek(winnr)
+      vim.cmd('redraw')
+   end
 end
 
 function numb.on_cmdline_exit() unpeek(api.nvim_get_current_win()) end


### PR DESCRIPTION
`redraw` call is required for the update when the user deletes all the
numbers from command line (e.g `:5` to `:`). But it is unnecessary for
confirming or exiting the cmdline.

The `redraw` calls are separated from the `peek` and `unpeek` logic and
remain uncalled in `on_cmdline_exit` function.