### PR TITLE
Add unfolding while peeking and confirming

### DIFF
--- a/lua/numb/log.lua
+++ b/lua/numb/log.lua
@@ -21,7 +21,7 @@ local default_config = {
   use_file = true,
 
   -- Any messages above this level will be logged.
-  level = "trace",
+  level = "warn",
 
   -- Level configuration
   modes = {


### PR DESCRIPTION
Setting the cursor in Neovim does not open the folds. Now, numb disables
the folding temporarily while peeking. If the user confirms the line
number, numb unfolds the new line number using `zv`