### PR TITLE
Add option number_only to peek when command contains only a number

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ You can customize the behaviour with following:
 require('numb').setup{
    show_numbers = true, -- Enable 'number' for the window while peeking
    show_cursorline = true -- Enable 'cursorline' for the window while peeking
+   number_only = false, -- Peek only when the command is only a number instead of when it starts with a number
 }
 ```
 

--- a/lua/numb/init.lua
+++ b/lua/numb/init.lua
@@ -85,7 +85,7 @@ function numb.on_cmdline_changed()
    log.trace('on_cmdline_changed()')
    local cmd_line = api.nvim_call_function('getcmdline', {})
    local winnr = api.nvim_get_current_win()
-   local num_str = cmd_line:match('^%d+')
+   local num_str = cmd_line:match('^%d+$')
    if num_str then
       peek(winnr, tonumber(num_str))
       cmd('redraw')

--- a/lua/numb/init.lua
+++ b/lua/numb/init.lua
@@ -12,6 +12,7 @@ local win_states = {}
 local opts = {
    show_numbers = true, -- Enable 'number' for the window while peeking
    show_cursorline = true, -- Enable 'cursorline' for the window while peeking
+   number_only = false, -- Peek only when the command is only a number instead of when it starts with a number
 }
 
 -- Window options that are manipulated and saved while peeking
@@ -85,7 +86,7 @@ function numb.on_cmdline_changed()
    log.trace('on_cmdline_changed()')
    local cmd_line = api.nvim_call_function('getcmdline', {})
    local winnr = api.nvim_get_current_win()
-   local num_str = cmd_line:match('^%d+$')
+   local num_str = cmd_line:match('^%d+' .. (opts.number_only and '$' or ''))
    if num_str then
       peek(winnr, tonumber(num_str))
       cmd('redraw')


### PR DESCRIPTION
A command that contains only a number is used to jump to that line, but a command that starts with a number and contains more than a number is not used to jump to another line, so we shouldn't peek in that case.