### PR TITLE
Add hide_relativenumbers option

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ You can customize the behaviour with following:
 require('numb').setup{
   show_numbers = true, -- Enable 'number' for the window while peeking
   show_cursorline = true, -- Enable 'cursorline' for the window while peeking
+  hide_relativenumbers = true -- Enable turning off 'relativenumber' for the window while peeking
   number_only = false, -- Peek only when the command is only a number instead of when it starts with a number
   centered_peeking = true, -- Peeked line will be centered relative to window
 }

--- a/lua/numb/init.lua
+++ b/lua/numb/init.lua
@@ -12,12 +12,13 @@ local win_states = {}
 local opts = {
   show_numbers = true, -- Enable 'number' for the window while peeking
   show_cursorline = true, -- Enable 'cursorline' for the window while peeking
+  hide_relativenumbers = true, -- Enable turning off 'relativenumber' for the window while peeking
   number_only = false, -- Peek only when the command is only a number instead of when it starts with a number
   centered_peeking = true, -- Peeked line will be centered relative to window
 }
 
 -- Window options that are manipulated and saved while peeking
-local tracked_win_options = { "number", "cursorline", "foldenable" }
+local tracked_win_options = { "number", "cursorline", "foldenable", "relativenumber" }
 
 --- Saves values of tracked window options of a window to given table
 local function save_win_state(states, winnr)
@@ -56,6 +57,9 @@ local function peek(winnr, linenr)
     number = opts.show_numbers and true or nil,
     cursorline = opts.show_cursorline and true or nil,
   }
+  if opts.hide_relativenumbers then
+    peeking_options.relativenumber = false
+  end
 
   set_win_options(winnr, peeking_options)
 


### PR DESCRIPTION
Turns off relativenumber in the current window while peeking.

The relativenumber option is useful for jumping around a file with `5j` or `7k` and requires less math in one's head to use. However if one is using `:<number>` they are switching to a mode where they only care about absolute line numbers, so it would be useful for the number line to also switch to absolute line numbers.

A new option `hide_relativenumbers` option is added so that users who don't like this behavior can easily turn it off. However, I left it on by default since I think it provides the best user experience to the most users.

https://user-images.githubusercontent.com/1505923/193432804-aba708e5-89f7-4408-8713-d483721c3e30.mp4

