### PR TITLE
feat: option to skip cmdline-history for numb

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ require('numb').setup{
   hide_relativenumbers = true, -- Enable turning off 'relativenumber' for the window while peeking
   number_only = false, -- Peek only when the command is only a number instead of when it starts with a number
   centered_peeking = true, -- Peeked line will be centered relative to window
+  skip_cmdline_history = false, -- Cmds will not be stored in the cmdline-history
 }
 ```
 

--- a/lua/numb/init.lua
+++ b/lua/numb/init.lua
@@ -15,6 +15,7 @@ local opts = {
   hide_relativenumbers = true, -- Enable turning off 'relativenumber' for the window while peeking
   number_only = false, -- Peek only when the command is only a number instead of when it starts with a number
   centered_peeking = true, -- Peeked line will be centered relative to window
+  skip_cmdline_history = false, -- cmds will not be stored in the cmdline-history
 }
 
 -- Window options that are manipulated and saved while peeking
@@ -137,6 +138,10 @@ function numb.on_cmdline_exit()
   local event = api.nvim_get_vvar "event"
   local stay = not event.abort
   unpeek(winnr, stay)
+
+  if opts.skip_cmdline_history then
+    vim.fn.histdel("cmd", -1)
+  end
 end
 
 function numb.setup(user_opts)

--- a/lua/numb/init.lua
+++ b/lua/numb/init.lua
@@ -140,7 +140,10 @@ function numb.on_cmdline_exit()
   unpeek(winnr, stay)
 
   if opts.skip_cmdline_history then
-    vim.fn.histdel("cmd", -1)
+    -- needs delay to ensure the item is already in the history
+    vim.defer_fn(function()
+      vim.fn.histdel(":", -1)
+    end, 1)
   end
 end
 

--- a/lua/numb/init.lua
+++ b/lua/numb/init.lua
@@ -142,7 +142,10 @@ function numb.on_cmdline_exit()
   if opts.skip_cmdline_history then
     -- needs delay to ensure the item is already in the history
     vim.defer_fn(function()
-      vim.fn.histdel(":", -1)
+      local cmdlineNotAborted = vim.fn.histget(":", -1):match "^%d+$"
+      if cmdlineNotAborted then
+        vim.fn.histdel(":", -1)
+      end
     end, 1)
   end
 end

--- a/lua/numb/init.lua
+++ b/lua/numb/init.lua
@@ -15,7 +15,7 @@ local opts = {
   hide_relativenumbers = true, -- Enable turning off 'relativenumber' for the window while peeking
   number_only = false, -- Peek only when the command is only a number instead of when it starts with a number
   centered_peeking = true, -- Peeked line will be centered relative to window
-  skip_cmdline_history = false, -- cmds will not be stored in the cmdline-history
+  skip_cmdline_history = false, -- Cmds will not be stored in the cmdline-history
 }
 
 -- Window options that are manipulated and saved while peeking


### PR DESCRIPTION
This way, going through the cmdline history via `<Up>` does not jump around in the buffer. Opt-in option.