### PR TITLE
Add lazy.nvim installation instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,17 @@ paq 'nacro90/numb.nvim'
 Plug 'nacro90/numb.nvim'
 ```
 
+### Lazy.nvim
+
+```lua
+{
+  'nacro90/numb.nvim',
+  config = function()
+    require('numb').setup()
+  end,
+}
+```
+
 ## Usage
 
 Setup with default options:


### PR DESCRIPTION
Adds configuration for the lazy.nvim package manager (since Packer was here already).

Technically the code could also use the `opt` parameter or `config = true` but that is marginally cleaner and is less understandable to a new user than just using the setup function.